### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
     
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/CJFWeatherhead/ChatrixCD/security/code-scanning/2](https://github.com/CJFWeatherhead/ChatrixCD/security/code-scanning/2)

To address this, add a `permissions` block specifying the minimal required permissions for this workflow. Since it only reads the repository contents to checkout and run tests, the safest and most appropriate setting is `contents: read`. Place the `permissions` block at the job level within the `test` job or at the root (top-level) of the workflow. The job-level placement is preferred if only one job requires different permissions; otherwise, the root is fine. For this single-job workflow, either works; the job-level placement provides more granular control for future changes.

Change required:  
- In `.github/workflows/test.yml`, add:  
```yaml
permissions:
  contents: read
```  
either above the `steps:` key within the `test:` job, or at the top level below the `name` or `on` block.
- No new methods or imports required—just a YAML edit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
